### PR TITLE
Fix association type error while using Globalize

### DIFF
--- a/lib/graphql/sugar/define/relationship.rb
+++ b/lib/graphql/sugar/define/relationship.rb
@@ -21,7 +21,8 @@ module GraphQL
           key_type = GraphQL::ID_TYPE
           key_property = association.foreign_key.to_sym
 
-          type = "Types::#{association.klass}Type".constantize
+          association_type = "#{association.klass}"
+          type = "Types::#{association_type.gsub('::', '')}Type".constantize
           property = association_name.to_sym
 
           key_column_details = Sugar.get_column_details(model_class, association.foreign_key)
@@ -39,7 +40,8 @@ module GraphQL
         def self.define_has_one_or_many(type_defn, field_name, _model_class, association_name, association)
           kwargs = {}
 
-          kwargs[:type] = "Types::#{association.klass}Type".constantize
+          association_type = "#{association.klass}"
+          kwargs[:type] = "Types::#{association_type.gsub('::', '')}Type".constantize
 
           if association.association_class == ActiveRecord::Associations::HasManyAssociation ||
             association.association_class == ActiveRecord::Associations::HasManyThroughAssociation

--- a/lib/graphql/sugar/object.rb
+++ b/lib/graphql/sugar/object.rb
@@ -55,7 +55,8 @@ module GraphQL
           key_type = GraphQL::ID_TYPE
           key_property = association.foreign_key.to_sym
 
-          type = "Types::#{association.klass}Type".constantize
+          association_type = "#{association.klass}"
+          type = "Types::#{association_type.gsub('::', '')}Type".constantize
           property = association_name.to_sym
 
           key_column_details = Sugar.get_column_details(@model_class, association.foreign_key)
@@ -66,7 +67,8 @@ module GraphQL
         end
 
         def define_has_one_or_many(field_name, association_name, association)
-          type = "Types::#{association.klass}Type".constantize
+          association_type = "#{association.klass}"
+          type = "Types::#{association_type.gsub('::', '')}Type".constantize
           is_null = true
 
           if association.association_class == ActiveRecord::Associations::HasManyAssociation ||


### PR DESCRIPTION
If you use Globalize gem, it adds Class::Translation to Class model.
Then you use `GraphQL::Sugar`, it tries to convert this class to GraphQL type, but it searches for `Types::Class` type which does not exist.

In this pull request I've changed searchable type name to `Types::ClassTranslationType`, so it can be simply created like other classes in _app/graphql/types_ directory.

So you can set there all translatable fields you need like:
```ruby
module Types
  class UserTranslationType < BaseObject
    model_class User::Translation

    attributes :locale, :first_name, :middle_name, :last_name
  end
end
```
and use such queries:
```
query {
  user {
    id
    email
    translations {
      locale
      firstName
      middleName
      lastName
    }
  }
}
```