### PR TITLE
Remove custom DateTime type, use one of the built-in scalar types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.1.7] - 2023-02-17
+### Changed
+- Support graphql-ruby 1.11
+- Removed custom DATETIME_TYPE
+
 ## [0.1.6] - 2018-05-18
 ### Fixed
 - Support for MySQL by conditionally checking PostgreSQL-specific `array?`

--- a/lib/graphql/datetime_type.rb
+++ b/lib/graphql/datetime_type.rb
@@ -1,7 +1,0 @@
-GraphQL::DATETIME_TYPE = GraphQL::ScalarType.define do
-  name 'DateTime'
-  description 'An ISO 8601-encoded datetime'
-
-  coerce_input ->(value, _ctx) { Time.zone.parse(value) rescue nil }
-  coerce_result ->(value, _ctx) { value.utc.iso8601 }
-end

--- a/lib/graphql/sugar.rb
+++ b/lib/graphql/sugar.rb
@@ -9,7 +9,10 @@ module GraphQL
       decimal: GraphQL::FLOAT_TYPE,
       boolean: GraphQL::BOOLEAN_TYPE,
       string: GraphQL::STRING_TYPE,
-      datetime: GraphQL::DATETIME_TYPE
+      datetime: GraphQL::ISO_8601_DATE_TIME_TYPE,
+      date: GraphQL::ISO_8601_DATE_TYPE,
+      json: GraphQL::JSON_TYPE,
+      jsonb: GraphQL::JSON_TYPE
     }.freeze
 
     def self.get_resolver_graphql_type(field_name)

--- a/lib/graphql/sugar.rb
+++ b/lib/graphql/sugar.rb
@@ -7,11 +7,7 @@ module GraphQL
       float: GraphQL::FLOAT_TYPE,
       decimal: GraphQL::FLOAT_TYPE,
       boolean: GraphQL::BOOLEAN_TYPE,
-      string: GraphQL::STRING_TYPE,
-      datetime: GraphQL::ISO_8601_DATE_TIME_TYPE,
-      date: GraphQL::ISO_8601_DATE_TYPE,
-      json: GraphQL::JSON_TYPE,
-      jsonb: GraphQL::JSON_TYPE
+      string: GraphQL::STRING_TYPE
     }.freeze
 
     def self.get_resolver_graphql_type(field_name)

--- a/lib/graphql/sugar.rb
+++ b/lib/graphql/sugar.rb
@@ -1,5 +1,4 @@
 require 'graphql/sugar/version'
-require 'graphql/datetime_type'
 
 module GraphQL
   module Sugar


### PR DESCRIPTION
Remove custom DateTime type, use one of the built-in scalar types